### PR TITLE
Proposal for Issue 5

### DIFF
--- a/src/RDA5807M.cpp
+++ b/src/RDA5807M.cpp
@@ -271,7 +271,7 @@ void RDA5807M::seekUp(bool toNextSender) {
   registers[RADIO_REG_CTRL] &= (~RADIO_REG_CTRL_SEEK); // clear seekmode
   if (! toNextSender) {
     // stop scanning right now
-    registers[RADIO_REG_CTRL] &= (~RADIO_REG_CTRL_SEEK);
+    //registers[RADIO_REG_CTRL] &= (~RADIO_REG_CTRL_SEEK);
     _saveRegister(RADIO_REG_CTRL);
   } // if
 } // seekUp()

--- a/src/RDA5807M.cpp
+++ b/src/RDA5807M.cpp
@@ -268,6 +268,7 @@ void RDA5807M::seekUp(bool toNextSender) {
   registers[RADIO_REG_CTRL] |= RADIO_REG_CTRL_SEEK;
   _saveRegister(RADIO_REG_CTRL);
 
+  registers[RADIO_REG_CTRL] &= (~RADIO_REG_CTRL_SEEK); // clear seekmode
   if (! toNextSender) {
     // stop scanning right now
     registers[RADIO_REG_CTRL] &= (~RADIO_REG_CTRL_SEEK);
@@ -282,9 +283,9 @@ void RDA5807M::seekDown(bool toNextSender) {
   registers[RADIO_REG_CTRL] |= RADIO_REG_CTRL_SEEK;
   _saveRegister(RADIO_REG_CTRL);
 
+  registers[RADIO_REG_CTRL] &= (~RADIO_REG_CTRL_SEEK); // clear seekmode
   if (! toNextSender) {
     // stop scanning right now
-    registers[RADIO_REG_CTRL] &= (~RADIO_REG_CTRL_SEEK);
     _saveRegister(RADIO_REG_CTRL);
   } // if
 } // seekDown()


### PR DESCRIPTION
Register for CTRL within seek function is not cleared if bool toNextSender is "true".
Proposed solution: "registers[RADIO_REG_CTRL] &= (~RADIO_REG_CTRL_SEEK);"  should be outside (before) if-statement.