### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,10 +8,10 @@
 #######################################
 
 RDA5807M	KEYWORD1
-RADIO	    KEYWORD1
-SI4703	    KEYWORD1
-SI4705	    KEYWORD1
-TEA5767	    KEYWORD1
+RADIO	KEYWORD1
+SI4703	KEYWORD1
+SI4705	KEYWORD1
+TEA5767	KEYWORD1
 
 RADIO_FREQ	KEYWORD1
 RADIO_BAND	KEYWORD1
@@ -22,42 +22,42 @@ AUDIO_INFO	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init  KEYWORD2
-term  KEYWORD2
+init	KEYWORD2
+term	KEYWORD2
 
-setVolume     KEYWORD2
-getVolume     KEYWORD2
-setBassBoost  KEYWORD2
-getBassBoost  KEYWORD2
-setMono       KEYWORD2
-getMono       KEYWORD2
-setMute       KEYWORD2
-getMute       KEYWORD2
-setSoftMute   KEYWORD2
-getSoftMute   KEYWORD2
+setVolume	KEYWORD2
+getVolume	KEYWORD2
+setBassBoost	KEYWORD2
+getBassBoost	KEYWORD2
+setMono	KEYWORD2
+getMono	KEYWORD2
+setMute	KEYWORD2
+getMute	KEYWORD2
+setSoftMute	KEYWORD2
+getSoftMute	KEYWORD2
 
-setBand       KEYWORD2
-getBand       KEYWORD2
+setBand	KEYWORD2
+getBand	KEYWORD2
 
-setFrequency  KEYWORD2
-getFrequency  KEYWORD2
+setFrequency	KEYWORD2
+getFrequency	KEYWORD2
 
-setBandFrequency  KEYWORD2
+setBandFrequency	KEYWORD2
 
-seekUp        KEYWORD2
-seekDown      KEYWORD2
+seekUp	KEYWORD2
+seekDown	KEYWORD2
 
-getMinFrequency   KEYWORD2
-getMaxFrequency   KEYWORD2
-getFrequencyStep  KEYWORD2
+getMinFrequency	KEYWORD2
+getMaxFrequency	KEYWORD2
+getFrequencyStep	KEYWORD2
 
-getRadioInfo  KEYWORD2
-getAudioInfo  KEYWORD2
+getRadioInfo	KEYWORD2
+getAudioInfo	KEYWORD2
 
-checkRDS          KEYWORD2
-attachReceiveRDS  KEYWORD2
+checkRDS	KEYWORD2
+attachReceiveRDS	KEYWORD2
 
-formatFrequency   KEYWORD2
+formatFrequency	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords