### PR TITLE
Add Travis CI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 *.exe
 *.out
 *.app
+
+# DoxyGen files
+html/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+# This will run on Travis' 'new' container-based infrastructure
+sudo: false 
+
+# Blacklist
+branches:
+  only:
+    - master
+
+# Install dependencies
+addons:
+  apt:
+    packages:
+      - doxygen
+
+# Build your code e.g. by calling make
+script:
+  - doxygen Doxyfile
+  - cp README.md html/README.md 
+  - "echo 'title: Radio' > html/_config.yml"
+  - "echo 'description: An Arduino library to control radio chips like SI4703, SI4703, RDA5807M, TEA5768.' >> html/_config.yml"
+  - "echo 'show_downloads: true' >> html/_config.yml"
+  - "echo 'google_analytics:' >> html/_config.yml"
+  - "echo 'theme: jekyll-theme-architect' >> html/_config.yml"
+
+# Generate and deploy documentation
+deploy:
+  provider: pages
+  skip_cleanup: true
+  keep_history: true
+  local_dir: html
+  github_token: $GH_REPO_TOKEN
+  on:
+    branch: master

--- a/Doxyfile
+++ b/Doxyfile
@@ -51,7 +51,7 @@ PROJECT_BRIEF          = "A set of Arduino libraries to control diverse FM radio
 # and the maximum width should not exceed 200 pixels. Doxygen will copy the logo
 # to the output directory.
 
-PROJECT_LOGO           = C:/Users/Matthias/Projekte/Arduino/Sketches/libraries/Radio/Radio_Logo.png
+PROJECT_LOGO           = ./Radio_Logo.png
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is


### PR DESCRIPTION
This PR allow to auto-generate the project documentation after one commit over the master branch.

- Execute doxygen to generate the html folder.
- Generate the _config.yml file used by github pages
- Copy the README.md to html documentation folder
- Deploy all the files to gh-pages.

In order to made this PR work the owner of the repository must:

1. Enable Travis CI for the user account (https://github.com/marketplace/travis-ci)
2. Enable Travis CI for this repository (https://travis-ci.org/)
3. [Generate personal access tokens](https://github.com/settings/tokens) with public_repo scope
4.Add this token in Travis CI -> Your Project -> Settings -> Environment Variables as GH_REPO_TOKEN

Should be merged after #30

