### PR TITLE
Added Si4703 RDS error detection and GPIO-write-feature 

### DIFF
--- a/src/SI4703.cpp
+++ b/src/SI4703.cpp
@@ -160,6 +160,8 @@ bool SI4703::init() {
   registers[SYSCONFIG3] &= ~(SKSNR_MASK); // Clear seek mask bits
   registers[SYSCONFIG3] |= SKSNR_MID;     //Set volume
   
+  registers[POWERCFG] |= (1 << RDSMODE); // set force verbose bit
+	  
   _saveRegisters(); //Update
 
   delay(110); //Max powerup time, from datasheet page 13
@@ -238,17 +240,6 @@ void SI4703::setSoftMute(bool switchOn)
 
 } // setSoftMute()
 
-void SI4703::setRDSVerbose(bool verbose)
-{
-  DEBUG_FUNC1("setRDSVerbose", verbose);
-  _readRegisters(); //Read the current register set
-  if (verbose) {
-    registers[POWERCFG] |= (1 << RDSMODE); // set force verbose bit
-  } else {
-    registers[POWERCFG] &= ~(1 << RDSMODE); // clear force verbose bit
-  } // if
-  _saveRegisters();
-} // setRDSVerbose()
 
 // ----- Band and frequency control methods -----
 

--- a/src/SI4703.cpp
+++ b/src/SI4703.cpp
@@ -16,9 +16,15 @@
 /// * 05.08.2014 created.
 
 #include <Arduino.h>
+#include <Wire.h>     // The chip is controlled via the standard Arduiino Wire library and the IIC/I2C bus.
 
+#include <radio.h>    // Include the common radio library interface
 #include <SI4703.h>
-#include <radio.h> // Include the common radio library interface
+
+// ----- Definitions for the Wire communication
+
+#define SI4703_ADR 0x10 //0b._001.0000 = I2C address of Si4703 - note that the Wire function assumes non-left-shifted I2C address, not 0b.0010.000W
+#define I2C_FAIL_MAX  10 //This is the number of attempts we will try to contact the device before erroring out
 
 
 // ----- Radio chip specific definitions including the registers
@@ -32,106 +38,98 @@
 
 // Define the register names
 #define DEVICEID 0x00
-#define CHIPID 0x01
-#define POWERCFG 0x02
-#define CHANNEL 0x03
-#define SYSCONFIG1 0x04
-#define SYSCONFIG2 0x05
+#define CHIPID  0x01
+#define POWERCFG  0x02
+#define CHANNEL  0x03
+#define SYSCONFIG1  0x04
+#define SYSCONFIG2  0x05
 #define SYSCONFIG3 0x06
-#define STATUSRSSI 0x0A
-#define READCHAN 0x0B
-#define RDSA 0x0C
-#define RDSB 0x0D
-#define RDSC 0x0E
-#define RDSD 0x0F
+#define STATUSRSSI  0x0A
+#define READCHAN  0x0B
+#define RDSA  0x0C
+#define RDSB  0x0D
+#define RDSC  0x0E
+#define RDSD  0x0F
 
 //Register 0x02 - POWERCFG
-#define DSMUTE 15
-#define DMUTE 14
-#define SETMONO 13
-#define SKMODE 10
-#define SEEKUP 9
-#define SEEK 8
+#define DSMUTE  15
+#define DMUTE  14
+#define SETMONO  13
+#define RDSMODE 11
+#define SKMODE  10
+#define SEEKUP  9
+#define SEEK  8
 
 //Register 0x03 - CHANNEL
-#define TUNE 15
+#define TUNE  15
 
 //Register 0x04 - SYSCONFIG1
-#define RDS 12
-#define DE 11
+#define RDS  12
+#define DE  11
 
-#define DE 11
+#define DE  11
 
 
 //Register 0x05 - SYSCONFIG2
 #define SEEKTH_MASK 0xFF00
-#define SEEKTH_MIN 0x0000
-#define SEEKTH_MID 0x1000
-#define SEEKTH_MAX 0x7F00
+#define SEEKTH_MIN  0x0000
+#define SEEKTH_MID  0x1000
+#define SEEKTH_MAX  0x7F00
 
-#define SPACE1 5
-#define SPACE0 4
+#define SPACE1  5
+#define SPACE0  4
 
 // Register 0x06 - SYSCONFIG3
 #define SKSNR_MASK 0x00F0
-#define SKSNR_OFF 0x0000
-#define SKSNR_MIN 0x0010
-#define SKSNR_MID 0x0030
-#define SKSNR_MAX 0x0070
+#define SKSNR_OFF  0x0000
+#define SKSNR_MIN  0x0010
+#define SKSNR_MID  0x0030
+#define SKSNR_MAX  0x0070
 
 #define SKCNT_MASK 0x000F
-#define SKCNT_OFF 0x0000
-#define SKCNT_MIN 0x000F
-#define SKCNT_MID 0x0003
-#define SKCNT_MAX 0x0001
+#define SKCNT_OFF  0x0000
+#define SKCNT_MIN  0x000F
+#define SKCNT_MID  0x0003
+#define SKCNT_MAX  0x0001
+
 
 
 //Register 0x0A - STATUSRSSI
-#define RDSR 0x8000 ///<RDS ready
-#define STC 0x4000 ///<Seek Tune Complete
-#define SFBL 0x2000 ///< Seek Fail Band Limit
-#define AFCRL 0x1000
-#define RDSS 0x0800 ///<RDS syncronized
-#define SI 0x0100 ///< Stereo Indicator
-#define RSSI 0x00FF
+#define RDSR   0x8000 ///<RDS ready
+#define STC    0x4000 ///<Seek Tune Complete
+#define SFBL   0x2000 ///< Seek Fail Band Limit
+#define AFCRL  0x1000
+#define RDSS   0x0800 ///<RDS syncronized
+#define SI     0x0100 ///< Stereo Indicator
+#define RSSI   0x00FF
 
 // ----- implement
 
 // initialize the extra variables in SI4703
-SI4703::SI4703()
-{
-  _i2caddr = 0x10; // standard address of chip
+SI4703::SI4703(uint8_t resetPin, uint8_t sdaPin) {
+  _resetPin = resetPin;
+  _sdaPin = sdaPin;
 }
 
+// initialize all internals.
+bool SI4703::init() {
+  bool result = false; // no chip found yet.
+  DEBUG_FUNC0("init");
 
-void SI4703::setup(int feature, int value)
-{
-  RADIO::setup(feature, value);
-  if (feature == RADIO_SDAPIN) {
-    _sdaPin = value;
-  } // if
-} // setup()
-
-
-// initialize all internals and communication to radio chip.
-bool SI4703::init()
-{
-  bool found; // no chip found yet.
-  DEBUG_FUNC0("SI4703::init");
-
-  //To get the Si4703 in 2-wire mode, SEN needs to be high and SDIO/SDA needs to be low after a reset
+  //To get the Si4703 inito 2-wire mode, SEN needs to be high and SDIO needs to be low after a reset
   //The breakout board has SEN pulled high, but also has SDIO pulled high. Therefore, after a normal power up
   //The Si4703 will be in an unknown state. RST must be controlled
 
-  if (_sdaPin >= 0) {
-    pinMode(_sdaPin, OUTPUT); // SDIO is connected to SDA for I2C
-    digitalWrite(_sdaPin, LOW); //A low SDA during reset indicates a 2-wire interface
-  }
+  pinMode(_resetPin, OUTPUT);
+  pinMode(_sdaPin, OUTPUT); // SDIO is connected to SDA for I2C
+  digitalWrite(_sdaPin, LOW); //A low SDA during reset indicates a 2-wire interface
+  digitalWrite(_resetPin, LOW); //Put Si4703 into reset
+  delay(1); //Some delays while we allow pins to settle
 
-  RADIO::init(); // will create reset impulse
+  digitalWrite(_resetPin, HIGH); //Bring Si4703 out of reset with SDIO set to low and SEN pulled high with on-board resistor
+  delay(1); //Allow Si4703 to come out of reset
 
-  _i2cPort->begin(); //Now that the unit is reset and I2C inteface mode, we need to begin I2C
-  found = RADIO::_wireExists(_i2cPort, _i2caddr);
+  Wire.begin(); //Now that the unit is reset and I2C inteface mode, we need to begin I2C
 
   _readRegisters(); //Read the current register set
   //registers[0x07] = 0xBC04; //Enable the oscillator, from AN230 page 9, rev 0.5 (DOES NOT WORK, wtf Silicon Labs datasheet?)
@@ -140,14 +138,40 @@ bool SI4703::init()
 
   delay(500); //Wait for clock to settle - from AN230 page 9
 
-  return (found);
+  _readRegisters(); //Read the current register set
+  registers[POWERCFG] = 0x4001; //Enable the IC
+  //  registers[POWERCFG] |= (1<<DSMUTE) | (1<<DMUTE); //Disable Mute, disable softmute
+  registers[SYSCONFIG1] |= (1<<RDS); //Enable RDS
+  // registers[SYSCONFIG1] |= 0x0010;  //Enable GPIO3 as Stereo indicator ==> is not working with me.
+
+  #ifdef IN_EUROPE
+  registers[SYSCONFIG1] |= (1<<DE); //50kHz Europe setup
+  registers[SYSCONFIG2] |= (1<<SPACE0); //100kHz channel spacing for Europe
+  #else
+  registers[SYSCONFIG2] &= ~(1<<SPACE1 | 1<<SPACE0) ; //Force 200kHz channel spacing for USA
+  #endif
+
+  _volume = 1;
+  registers[SYSCONFIG2] &= 0xFFF0; //Clear volume bits
+  registers[SYSCONFIG2] |= (_volume & 0x0F); //Set volume
+  registers[SYSCONFIG2] |= SEEKTH_MID; //Set volume
+
+  // set seek parameters
+  registers[SYSCONFIG3] &= ~(SKSNR_MASK); // Clear seek mask bits
+  registers[SYSCONFIG3] |= SKSNR_MID;     //Set volume
+  
+  _saveRegisters(); //Update
+
+  delay(110); //Max powerup time, from datasheet page 13
+
+  return(result);
 } // init()
 
 
 // switch the power off
 void SI4703::term()
 {
-  RADIO::term();
+  DEBUG_FUNC0("term");
 } // term
 
 
@@ -156,8 +180,7 @@ void SI4703::term()
 void SI4703::setVolume(uint8_t newVolume)
 {
   DEBUG_FUNC1("setVolume", newVolume);
-  if (newVolume > 15)
-    newVolume = 15;
+  if (newVolume > 15) newVolume = 15;
   _readRegisters(); //Read the current register set
   registers[SYSCONFIG2] &= 0xFFF0; //Clear volume bits
   registers[SYSCONFIG2] |= newVolume; //Set new volume
@@ -174,7 +197,8 @@ void SI4703::setMono(bool switchOn)
   _readRegisters(); //Read the current register set
   if (switchOn) {
     registers[POWERCFG] |= (1 << SETMONO); // set force mono bit
-  } else {
+  }
+  else {
     registers[POWERCFG] &= ~(1 << SETMONO); // clear force mono bit
   } // if
   _saveRegisters();
@@ -188,9 +212,10 @@ void SI4703::setMute(bool switchOn)
   RADIO::setMute(switchOn);
 
   if (switchOn) {
-    registers[POWERCFG] &= ~(1 << DMUTE); // clear mute bit
-  } else {
-    registers[POWERCFG] |= (1 << DMUTE); // set mute bit
+    registers[POWERCFG] &= ~(1<<DMUTE); // clear mute bit
+  }
+  else {
+    registers[POWERCFG] |= (1<<DMUTE); // set mute bit
   } // if
   _saveRegisters();
 
@@ -204,60 +229,45 @@ void SI4703::setSoftMute(bool switchOn)
   RADIO::setSoftMute(switchOn);
 
   if (switchOn) {
-    registers[POWERCFG] &= ~(1 << DSMUTE); // clear mute bit
-  } else {
-    registers[POWERCFG] |= (1 << DSMUTE); // set mute bit
+    registers[POWERCFG] &= ~(1<<DSMUTE); // clear mute bit
+  }
+  else {
+    registers[POWERCFG] |= (1<<DSMUTE); // set mute bit
   } // if
   _saveRegisters();
 
 } // setSoftMute()
 
+void SI4703::setRDSVerbose(bool verbose)
+{
+  DEBUG_FUNC1("setRDSVerbose", verbose);
+  _readRegisters(); //Read the current register set
+  if (verbose) {
+    registers[POWERCFG] |= (1 << RDSMODE); // set force verbose bit
+  } else {
+    registers[POWERCFG] &= ~(1 << RDSMODE); // clear force verbose bit
+  } // if
+  _saveRegisters();
+} // setRDSVerbose()
 
 // ----- Band and frequency control methods -----
 
 // tune to new band.
-void SI4703::setBand(RADIO_BAND newBand)
-{
+void SI4703::setBand(RADIO_BAND newBand) {
 
   if (newBand == RADIO_BAND_FM) {
-    // init chip here for FM
     RADIO::setBand(newBand);
     _freqLow = 8750;
 
-    _readRegisters(); //Read the current register set
+    #ifdef IN_EUROPE
+    //Freq(MHz) = 0.100(in Europe) * Channel + 87.5MHz
+    _freqSteps = 10;
 
-    // PowerConfig
-    registers[POWERCFG] = 0x4001; //Enable the IC
-    if (!_mute)
-      registers[POWERCFG] |= (1 << DMUTE); // disable Mute
-    if (!_softMute)
-      registers[POWERCFG] |= (1 << DSMUTE); // disable softmute
+    #else
+    //Freq(MHz) = 0.200(in USA) * Channel + 87.5MHz
+    _freqSteps = 20;
+    #endif
 
-    registers[SYSCONFIG1] |= (1 << RDS); //Enable RDS
-
-    // registers[SYSCONFIG1] |= 0x0010;  //Enable GPIO3 as Stereo indicator ==> is not working with me.
-
-#ifdef IN_EUROPE
-    registers[SYSCONFIG1] |= (1 << DE); //50kHz Europe setup
-    registers[SYSCONFIG2] |= (1 << SPACE0); //100kHz channel spacing for Europe
-#else
-    registers[SYSCONFIG2] &= ~(1 << SPACE1 | 1 << SPACE0); //Force 200kHz channel spacing for USA
-#endif
-
-    _volume = 1;
-    registers[SYSCONFIG2] &= 0xFFF0; //Clear volume bits
-    registers[SYSCONFIG2] |= (_volume & 0x0F); //Set volume
-
-    // set seek parameters
-    registers[SYSCONFIG2] |= SEEKTH_MID; //Set volume
-    registers[SYSCONFIG3] &= ~(SKSNR_MASK); // Clear seek mask bits
-    registers[SYSCONFIG3] |= SKSNR_MID; //Set volume
-
-    registers[SYSCONFIG3] &= ~(SKCNT_MASK); // Clear seek mask bits
-    registers[SYSCONFIG3] |= SKCNT_MID; //Set volume
-
-    _saveRegisters(); //Update
-    delay(110); //Max powerup time, from datasheet page 13
   } // if
 } // setBand()
 
@@ -266,13 +276,12 @@ void SI4703::setBand(RADIO_BAND newBand)
 * @brief Retrieve the real frequency from the chip after automatic tuning.
 * @return RADIO_FREQ the current frequency.
 */
-RADIO_FREQ SI4703::getFrequency()
-{
+RADIO_FREQ SI4703::getFrequency() {
   _readRegisters();
   int channel = registers[READCHAN] & 0x03FF; //Mask out everything but the lower 10 bits
   _freq = (channel * _freqSteps) + _freqLow;
   return (_freq);
-} // getFrequency
+}  // getFrequency
 
 
 /**
@@ -280,13 +289,10 @@ RADIO_FREQ SI4703::getFrequency()
 * @param newF
 * @return void
 */
-void SI4703::setFrequency(RADIO_FREQ newF)
-{
+void SI4703::setFrequency(RADIO_FREQ newF) {
   DEBUG_FUNC1("setFrequency", newF);
-  if (newF < _freqLow)
-    newF = _freqLow;
-  if (newF > _freqHigh)
-    newF = _freqHigh;
+  if (newF < _freqLow)  newF = _freqLow;
+  if (newF > _freqHigh) newF = _freqHigh;
 
   _readRegisters();
   int channel = (newF - _freqLow) / _freqSteps;
@@ -294,41 +300,38 @@ void SI4703::setFrequency(RADIO_FREQ newF)
   //These steps come from AN230 page 20 rev 0.5
   registers[CHANNEL] &= 0xFE00; //Clear out the channel bits
   registers[CHANNEL] |= channel; //Mask in the new channel
-  registers[CHANNEL] |= (1 << TUNE); //Set the TUNE bit to start
+  registers[CHANNEL] |= (1<<TUNE); //Set the TUNE bit to start
   _saveRegisters();
   _waitEnd();
 } // setFrequency()
 
 
 // start seek mode upwards
-void SI4703::seekUp(bool toNextSender)
-{
+void SI4703::seekUp(bool toNextSender) {
   DEBUG_FUNC1("seekUp", toNextSender);
   _seek(true);
 } // seekUp()
 
 
 // start seek mode downwards
-void SI4703::seekDown(bool toNextSender)
-{
+void SI4703::seekDown(bool toNextSender) {
   DEBUG_FUNC1("seekDown", toNextSender);
   _seek(false);
 } // seekDown()
+
 
 
 // Load all status registers from to the chip
 void SI4703::_readRegisters()
 {
   //Si4703 begins reading from register upper register of 0x0A and reads to 0x0F, then loops to 0x00.
-  _i2cPort->requestFrom(_i2caddr, 32); //We want to read the entire register set from 0x0A to 0x09 = 32 bytes.
+  Wire.requestFrom(SI4703_ADR, 32); //We want to read the entire register set from 0x0A to 0x09 = 32 bytes.
 
   //Remember, register 0x0A comes in first so we have to shuffle the array around a bit
-  for (int x = 0x0A;; x++) { //Read in these 32 bytes
-    if (x == 0x10)
-      x = 0; //Loop back to zero
-    registers[x] = _read16HL(_i2cPort);
-    if (x == 0x09)
-      break; //We're done!
+  for(int x = 0x0A ; ; x++) { //Read in these 32 bytes
+    if(x == 0x10) x = 0; //Loop back to zero
+    registers[x] = _read16();
+    if(x == 0x09) break; //We're done!
   } // for
 } // _readRegisters()
 
@@ -342,56 +345,75 @@ void SI4703::_saveRegisters()
   //It's a little weird, you don't write an I2C addres
   //The Si4703 assumes you are writing to 0x02 first, then increments
 
-  _i2cPort->beginTransmission(_i2caddr);
+  Wire.beginTransmission(SI4703_ADR);
   //A write command automatically begins with register 0x02 so no need to send a write-to address
   //First we send the 0x02 to 0x07 control registers
   //In general, we should not write to registers 0x08 and 0x09
-  for (int regSpot = 0x02; regSpot < 0x08; regSpot++) {
-    _write16HL(_i2cPort, registers[regSpot]);
+  for(int regSpot = 0x02 ; regSpot < 0x08 ; regSpot++) {
+    byte high_byte = registers[regSpot] >> 8;
+    byte low_byte = registers[regSpot] & 0x00FF;
+
+    Wire.write(high_byte); //Upper 8 bits
+    Wire.write(low_byte); //Lower 8 bits
   }
 
   //End this transmission
-  byte ack = _i2cPort->endTransmission();
-  if (ack != 0) { //We have a problem!
+  byte ack = Wire.endTransmission();
+  if(ack != 0) { //We have a problem!
     Serial.print("Write Fail:"); //No ACK!
     Serial.println(ack, DEC); //I2C error: 0 = success, 1 = data too long, 2 = rx NACK on address, 3 = rx NACK on data, 4 = other error
   }
+
 } // _saveRegisters
 
 
-/// Retrieve all the information related to the current radio receiving situation.
-void SI4703::getRadioInfo(RADIO_INFO *info)
+// write a register value using 2 bytes into the Wire.
+void SI4703::_write16(uint16_t val)
 {
+  Wire.write(val >> 8); Wire.write(val & 0xFF);
+} // _write16
+
+
+// read a register value using 2 bytes in a row
+uint16_t SI4703::_read16(void)
+{
+  uint8_t hiByte = Wire.read();
+  uint8_t loByte = Wire.read();
+  return((hiByte << 8) + loByte);
+} // _read16
+
+
+
+/// Retrieve all the information related to the current radio receiving situation.
+void SI4703::getRadioInfo(RADIO_INFO *info) {
   RADIO::getRadioInfo(info); // all settings to last current settings
 
   _readRegisters();
   info->active = true; // ???
-  if (registers[STATUSRSSI] & SI)
-    info->stereo = true;
+  if (registers[STATUSRSSI] & SI) info->stereo = true;
   info->rssi = registers[STATUSRSSI] & RSSI;
-  if (registers[STATUSRSSI] & (RDSS))
-    info->rds = true;
-  if (registers[STATUSRSSI] & STC)
-    info->tuned = true;
-  if (registers[POWERCFG] & (1 << SETMONO))
-    info->mono = true;
+  if (registers[STATUSRSSI] & (RDSS)) info->rds = true;
+  if (registers[STATUSRSSI] & STC) info->tuned = true;
+  if (registers[POWERCFG] & (1 << SETMONO)) info->mono = true;
 } // getRadioInfo()
 
 
 /// Return current audio settings.
-void SI4703::getAudioInfo(AUDIO_INFO *info)
-{
+void SI4703::getAudioInfo(AUDIO_INFO *info) {
   RADIO::getAudioInfo(info);
 
   _readRegisters();
-  if (!(registers[POWERCFG] & (1 << DMUTE)))
-    info->mute = true;
-  if (!(registers[POWERCFG] & (1 << DSMUTE)))
-    info->softmute = true;
+  if (! (registers[POWERCFG] & (1<<DMUTE))) info->mute = true;
+  if (! (registers[POWERCFG] & (1<<DSMUTE))) info->softmute = true;
   info->bassBoost = false; // no bassBoost
   info->volume = registers[SYSCONFIG2] & 0x000F;
 } // getAudioInfo()
 
+
+/*uint16_t SI4703::getRSSIRegister()
+{
+  return RSSIRegister;
+} //*/
 
 void SI4703::checkRDS()
 {
@@ -401,12 +423,46 @@ void SI4703::checkRDS()
   if (_sendRDS) {
     _readRegisters();
     // check for a RDS data set ready
-    if (registers[STATUSRSSI] & RDSR) {
-      _sendRDS(registers[RDSA], registers[RDSB], registers[RDSC], registers[RDSD]);
+	if(registers[STATUSRSSI] & RDSR) {
+	  uint8_t errA = (registers[STATUSRSSI] >> 9) & 3;
+	  uint8_t errB = (registers[READCHAN] >> 14) & 3;
+	  uint8_t errC = (registers[READCHAN] >> 12) & 3;
+	  uint8_t errD = (registers[READCHAN] >> 10) & 3;
+      if ( (errA != 3) && (errB != 3) && (errC != 3) && (errD != 3) ) 
+		_sendRDS(registers[RDSA], registers[RDSB], registers[RDSC], registers[RDSD]);
+	  /*Serial.print(" = 0x"); _printHex4( (registers[STATUSRSSI] >> 9)&3 ); Serial.print(' ');
+	  Serial.print(" = 0x"); _printHex4( (registers[READCHAN] >> 14)&3 ); Serial.print(' ');
+	  Serial.print(" = 0x"); _printHex4( (registers[READCHAN] >> 12)&3 ); Serial.print(' ');
+	  Serial.print(" = 0x"); _printHex4( (registers[READCHAN] >> 10)&3 ); Serial.println();*/
     } // if
   } // if
 } // checkRDS
 
+
+void SI4703::writeGPIO(int GPIO, int val)
+{
+  _readRegisters();    // Read the current register set
+
+  switch (GPIO)
+  {
+    case GPIO1:
+  	  registers[SYSCONFIG1] &= ~(0b11 << GPIO1);
+  	  registers[SYSCONFIG1] |= (val << GPIO1);
+      break;
+    case GPIO2:
+  	  registers[SYSCONFIG1] &= ~(0b11 << GPIO2);
+  	  registers[SYSCONFIG1] |= (val << GPIO2);
+      break;
+    case GPIO3:
+  	  registers[SYSCONFIG1] &= ~(0b11 << GPIO3);
+  	  registers[SYSCONFIG1] |= (val << GPIO3);
+      break;
+    default:
+      break;
+  }
+  _saveRegisters();  // Write to registers
+}
+  
 // ----- Debug functions -----
 
 /// Send the current values of all registers to the Serial port.
@@ -416,29 +472,25 @@ void SI4703::debugStatus()
 
   _readRegisters();
   // Print all registers for debugging
-  for (int x = 0; x < 16; x++) {
-    Serial.print("Reg: 0x0");
-    Serial.print(x, HEX);
-    Serial.print(" = 0x");
-    _printHex4(registers[x]);
+  for (int x = 0 ; x < 16 ; x++) {
+    Serial.print("Reg: 0x0"); Serial.print(x, HEX);
+    Serial.print(" = 0x"); _printHex4(registers[x]);
     Serial.println();
   } // for
 } // debugStatus
 
 
 /// Seeks out the next available station
-void SI4703::_seek(bool seekUp)
-{
+void SI4703::_seek(bool seekUp) {
   uint16_t reg;
 
   _readRegisters();
   // not wrapping around.
-  reg = registers[POWERCFG] & ~((1 << SKMODE) | (1 << SEEKUP));
+  reg = registers[POWERCFG] & ~((1<<SKMODE) | (1<<SEEKUP));
 
-  if (seekUp)
-    reg |= (1 << SEEKUP); // Set the Seek-up bit
+  if (seekUp) reg |= (1<<SEEKUP); // Set the Seek-up bit
 
-  reg |= (1 << SEEK); // Start seek now
+  reg |= (1<<SEEK); // Start seek now
 
   // save the registers and start seeking...
   registers[POWERCFG] = reg;
@@ -449,25 +501,24 @@ void SI4703::_seek(bool seekUp)
 
 
 /// wait until the current seek and tune operation is over.
-void SI4703::_waitEnd()
-{
+void SI4703::_waitEnd() {
   DEBUG_FUNC0("_waitEnd");
 
   // wait until STC gets high
   do {
     _readRegisters();
   } while ((registers[STATUSRSSI] & STC) == 0);
-
+  
   // DEBUG_VAL("Freq:", getFrequency());
-
+  
   _readRegisters();
   // get the SFBL bit.
   if (registers[STATUSRSSI] & SFBL)
-    DEBUG_STR("Seek limit hit");
-
+  DEBUG_STR("Seek limit hit");
+  
   // end the seek mode
-  registers[POWERCFG] &= ~(1 << SEEK);
-  registers[CHANNEL] &= ~(1 << TUNE); //Clear the tune after a tune has completed
+  registers[POWERCFG] &= ~(1<<SEEK);
+  registers[CHANNEL]  &= ~(1<<TUNE); //Clear the tune after a tune has completed
   _saveRegisters();
 
   // wait until STC gets down again
@@ -477,6 +528,9 @@ void SI4703::_waitEnd()
 } // _waitEnd()
 
 
+
 // ----- internal functions -----
 
 // The End.
+
+

--- a/src/SI4703.h
+++ b/src/SI4703.h
@@ -65,9 +65,6 @@ class SI4703 : public RADIO {
   // Control the softMute function of the radio chip
   void   setSoftMute(bool switchOn); // Switch to soft mute mode.
 
-  // Control the RDS verbose function of the radio chip
-  void   setRDSVerbose(bool verbose); // Switch to verbose mode.
-
   void   writeGPIO(int GPIO, int val);
 
   // Control of the core receiver

--- a/src/SI4703.h
+++ b/src/SI4703.h
@@ -26,46 +26,64 @@
 
 // ----- library definition -----
 
+// GPIO1-3 Pins
+static const uint8_t  	GPIO1			= 0;	// GPIO1
+static const uint8_t  	GPIO2			= 2;	// GPIO2
+static const uint8_t  	GPIO3			= 4;	// GPIO3
+
+// GPIO1-3 Possible Values
+static const uint8_t 	GPIO_Z			= 0b00;	// High impedance (default)
+static const uint8_t 	GPIO_I			= 0b01;	// GPIO1-Reserved, GPIO2-STC/RDS int, or GPIO3-Mono/Sterio Indicator
+static const uint8_t 	GPIO_Low		= 0b10;	// Low output (GND level)
+static const uint8_t 	GPIO_High		= 0b11;	// High output (VIO level)
 
 /// Library to control the SI4703 radio chip.
 class SI4703 : public RADIO {
-public:
-  const uint8_t MAXVOLUME = 15; ///< max volume level for radio implementations.
+  public:
+    const uint8_t MAXVOLUME = 15;   ///< max volume level for radio implementations.
 
-  SI4703();
+  SI4703(uint8_t resetPin = 2, uint8_t sdaPin = SDA);
+  
+  bool   init();  // initialize library and the chip.
+  void   term();  // terminate all radio functions.
+  
+  // SI4703 specific features
 
-  void setup(int feature, int value) override;
-  bool init() override; // initialize library and the chip.
-  void term() override; // terminate all radio functions.
+  void setResetPin(uint8_t pin);
 
   // Control of the audio features
-
+  
   // Control the volume output of the radio chip
-  void setVolume(uint8_t newVolume) override; ///< Control the volume output of the radio chip in the range 0..15.
+  void    setVolume(uint8_t newVolume); ///< Control the volume output of the radio chip in the range 0..15.
 
   // Control mono/stereo mode of the radio chip
-  void setMono(bool switchOn) override; // Switch to mono mode.
+  void   setMono(bool switchOn); // Switch to mono mode.
 
   // Control the mute function of the radio chip
-  void setMute(bool switchOn) override; // Switch to mute mode.
+  void   setMute(bool switchOn); // Switch to mute mode.
 
   // Control the softMute function of the radio chip
-  void setSoftMute(bool switchOn) override; // Switch to soft mute mode.
+  void   setSoftMute(bool switchOn); // Switch to soft mute mode.
 
+  // Control the RDS verbose function of the radio chip
+  void   setRDSVerbose(bool verbose); // Switch to verbose mode.
+
+  void   writeGPIO(int GPIO, int val);
 
   // Control of the core receiver
 
   // Control the frequency
-  void setBand(RADIO_BAND newBand) override;
+  void setBand(RADIO_BAND newBand);
 
-  void setFrequency(RADIO_FREQ newF);
+  void    setFrequency(RADIO_FREQ newF);
   RADIO_FREQ getFrequency(void);
 
   void seekUp(bool toNextSender = true);   // start seek mode upwards
   void seekDown(bool toNextSender = true); // start seek mode downwards
-
+  
+  //void checkRDS(); // read RDS data from the current station and process when data available.
   void checkRDS(); // read RDS data from the current station and process when data available.
-
+  
   // ----- combined status functions -----
 
   virtual void getRadioInfo(RADIO_INFO *info); ///< Retrieve some information about the current radio function of the chip.
@@ -73,26 +91,31 @@ public:
   virtual void getAudioInfo(AUDIO_INFO *info); ///< Retrieve some information about the current audio function of the chip.
 
   // ----- debug Helpers send information to Serial port
-
-  void debugScan();   // Scan all frequencies and report a status
-  void debugStatus(); // Report Info about actual Station
+  
+  void  debugScan();               // Scan all frequencies and report a status
+  void  debugStatus();             // Report Info about actual Station
 
   // ----- read/write registers of the chip
 
-  void _readRegisters(); // read all status & data registers
-  void _saveRegisters(); // Save writable registers back to the chip
+  void  _readRegisters();  // read all status & data registers
+  void  _saveRegisters();  // Save writable registers back to the chip
 
 private:
   // ----- local variables
-  uint8_t _sdaPin = -1;
 
   // store the current values of the 16 chip internal 16-bit registers
-  uint16_t registers[16];
+  uint16_t registers[16];  
 
   // ----- low level communication to the chip using I2C bus
 
+  void     _write16(uint16_t val);        // Write 16 Bit Value on I2C-Bus
+  uint16_t _read16(void);
+  
   void _seek(bool seekUp = true);
   void _waitEnd();
+
+  uint8_t _resetPin;
+  uint8_t _sdaPin;
 };
 
 #endif


### PR DESCRIPTION
Si4703:
- Trash broken RDS packets (puts receiver to RDS-verbose mode and checks if there is uncorrectable errors)
- Can write to GPIO e.g. radio.writeGPIO(GPIO1, GPIO_Low);