### PR TITLE
Added RDA5807FP with I2S support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A more detailed article is available at [www.mathertel.de/Arduino/RadioLibrary.a
 
 Currently the following radio receiver chips are supported:
 
-* The **RDA5807M** from RDA Microelectronics
+* The **RDA5807M** and **RDA5807FP** with I2S support from RDA Microelectronics
 * The **SI4703** from Silicon Labs
 * The **SI4705**, **SI4721** and **SI4730** chips from Silicon Labs
 * The **TEA5767** from NXP

--- a/examples/TestRDA5807FP/TestRDA5807FP.ino
+++ b/examples/TestRDA5807FP/TestRDA5807FP.ino
@@ -1,0 +1,97 @@
+  ///
+/// \file  TestRDA5807FP.ino
+/// \brief An Arduino sketch to operate a RDA5807FP chip based radio using the Radio library.
+///
+/// \author Marcus Degenkolbe, http://www.degenkolbe.eu
+/// \copyright Copyright (c) 2023 by Marcus Degenkolbe.\n
+/// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+///
+/// \details
+/// This sketch implements a simple radio without any possibility to modify the settings after initializing the chip.\n
+/// The radio chip is initialized and setup to a fixed band and frequency. These settings can be changed by modifying the 
+/// FIX_BAND and FIX_STATION definitions. The chip sends the output data via I2S to a compatible I2S DAC.
+///
+/// Open the Serial console with 57600 baud to see the current radio information.
+///
+/// Wiring
+/// ------ 
+/// The RDA5807FP board/chip has to be connected by using the following connections:
+/// | Arduino UNO pin    | Radio chip signal  | UDA1334A I2S DAC Board |
+/// | -------------------| -------------------| -----------------------|
+/// | 5V/VIN (red)       |                    | VIN                    |
+/// | 3.3V (red)         | VCC                |                        |
+/// | GND (black)        | GND                | GND                    |
+/// | A5 or SCL (yellow) | SCLK               |                        |
+/// | A4 or SDA (blue)   | SDIO               |                        |
+/// |                    | GPIO1 (WS)         | WS                     |
+/// |                    | GPIO2 (SD/DOUT)    | DIN                    |
+/// |                    | GPIO3 (SCK/BCLK)   | BCLK                   |
+/// The locations of the pins on the UNO board are written on the PCB.
+/// The locations of the signals on the RDA5807FP side depend on the board you use.
+///
+/// More documentation and source code is available at http://www.mathertel.de/Arduino
+///
+/// ChangeLog:
+/// ----------
+/// * 12.01.2023 created.
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <radio.h>
+#include <RDA5807FP.h>
+
+// ----- Fixed settings here. -----
+
+#define FIX_BAND     RADIO_BAND_FM   ///< The band that will be tuned by this sketch is FM.
+#define FIX_STATION  8930            ///< The station that will be tuned by this sketch is 89.30 MHz.
+#define FIX_VOLUME   4               ///< The volume that will be set by this sketch is level 4.
+
+RDA5807FP radio;    // Create an instance of Class for RDA5807FP Chip
+
+/// Setup a FM only radio configuration
+/// with some debugging on the Serial port
+void setup() {
+  // open the Serial port
+  Serial.begin(57600);
+  Serial.println("Radio...");
+  delay(200);
+
+  // Initialize the Radio 
+  radio.init();
+
+  // configure I2S
+  RDA5807FP_I2SConfig config;
+  config.enabled = true;
+  config.slave = false;
+  config.data_signed = true;
+  config.rate = RDA5807FP_I2S_WS_CNT::WS_STEP_48;
+
+  // Enable information to the Serial port
+  radio.debugEnable();
+
+  // Set all radio setting to the fixed values.
+  radio.setBandFrequency(FIX_BAND, FIX_STATION);
+  radio.setVolume(FIX_VOLUME);
+  radio.setMono(false);
+  radio.setMute(false);
+} // setup
+
+
+/// show the current chip data every 3 seconds.
+void loop() {
+  char s[12];
+  radio.formatFrequency(s, sizeof(s));
+  Serial.print("Station:"); 
+  Serial.println(s);
+  
+  Serial.print("Radio:"); 
+  radio.debugRadioInfo();
+  
+  Serial.print("Audio:"); 
+  radio.debugAudioInfo();
+
+  delay(3000);
+} // loop
+
+// End.
+

--- a/src/RDA5807FP.cpp
+++ b/src/RDA5807FP.cpp
@@ -1,0 +1,60 @@
+/// \file RDA5807FP.cpp
+/// \brief Implementation for the radio library to control the RDA5807FP radio chip.
+///
+/// \author Marcus Degenkolbe, http://www.degenkolbe.eu
+/// \copyright Copyright (c) 2023 by Marcus Degenkolbe.\n
+/// This work is licensed under a BSD style license.\n
+/// See http://www.mathertel.de/License.aspx
+///
+/// This library enables the use of the radio chip RDA5807FP from http://www.rdamicro.com/.
+///
+/// More documentation and source code is available at http://www.mathertel.de/Arduino
+///
+/// History:
+/// --------
+/// * 10.01.2023 created.
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <radio.h>
+
+#include <RDA5807FP.h>
+
+// ----- Register Definitions -----
+
+// this chip only supports FM mode
+
+#define RADIO_REG_R4 0x04
+#define RADIO_REG_R4_I2S 0xF0
+
+// regisrer R6 contains I2S options
+#define RADIO_REG_R6 0x06
+#define RADIO_REG_R6_I2S_WS_CNT 0xF0
+#define RADIO_REG_R6_I2S_DATA_SIGNED 0x200
+#define RADIO_REG_R6_I2S_MODE 0x1000
+
+// ----- implement
+
+// initialize the extra variables in RDA5807FP
+RDA5807FP::RDA5807FP()
+{
+
+}
+
+// Configures I2S output via GPIO1 (WS), GPIO2 (SD/DOUT), GPIO3 (SCK/BCLK)
+void RDA5807FP::SetupI2S(RDA5807FP_I2SConfig config)
+{
+  // enable I2S in register 0x4
+  registers[RADIO_REG_R4] = (registers[RADIO_REG_R4] & ~RADIO_REG_R4_I2S) | ((config.enabled << 6) & RADIO_REG_R4_I2S);
+  _saveRegister(RADIO_REG_R4);
+
+  // set I2S options in register 0x6
+  registers[RADIO_REG_R6] = (registers[RADIO_REG_R6] & ~RADIO_REG_R6_I2S_DATA_SIGNED) | ((config.data_signed << 9) & RADIO_REG_R6_I2S_DATA_SIGNED);
+  registers[RADIO_REG_R6] = (registers[RADIO_REG_R6] & ~RADIO_REG_R6_I2S_MODE) | ( (config.slave << 12) & RADIO_REG_R6_I2S_MODE);
+  registers[RADIO_REG_R6] = (registers[RADIO_REG_R6] & ~RADIO_REG_R6_I2S_WS_CNT) | ((config.rate << 4) & RADIO_REG_R6_I2S_WS_CNT);
+  _saveRegister(RADIO_REG_R6);
+}
+
+// ----- internal functions -----
+
+// The End.

--- a/src/RDA5807FP.h
+++ b/src/RDA5807FP.h
@@ -8,7 +8,7 @@
 /// See http://www.mathertel.de/License.aspx
 ///
 /// \details
-/// This library enables the use of the Radio Chip RDA5807FP from http://www.rdamicro.com/ that supports FM radio bands and RDS data.
+/// This library enables the use of the Radio Chip RDA5807FP from http://www.rdamicro.com/ that supports FM radio bands, RDS data and I2S output.
 ///
 /// More documentation and source code is available at http://www.mathertel.de/Arduino
 ///
@@ -16,7 +16,7 @@
 /// --------
 /// * 10.01.2023 created.
 
-// inherits all features from RDA5807M and adds I2S support
+// inherits all features from RDA5807M and adds basic I2S support
 
 #ifndef RDA5807FP_h
 #define RDA5807FP_h

--- a/src/RDA5807FP.h
+++ b/src/RDA5807FP.h
@@ -1,0 +1,61 @@
+///
+/// \file RDA5807FP.h
+/// \brief Library header file for the radio library to control the RDA5807FP radio chip.
+///
+/// \author Marcus Degenkolbe, http://www.degenkolbe.eu
+/// \copyright Copyright (c) 2023 by Marcus Degenkolbe.\n
+/// This work is licensed under a BSD style license.\n
+/// See http://www.mathertel.de/License.aspx
+///
+/// \details
+/// This library enables the use of the Radio Chip RDA5807FP from http://www.rdamicro.com/ that supports FM radio bands and RDS data.
+///
+/// More documentation and source code is available at http://www.mathertel.de/Arduino
+///
+/// History:
+/// --------
+/// * 10.01.2023 created.
+
+// inherits all features from RDA5807M and adds I2S support
+
+#ifndef RDA5807FP_h
+#define RDA5807FP_h
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <radio.h>
+#include <RDA5807M.h>
+
+enum RDA5807FP_I2S_WS_CNT
+{
+  WS_STEP_48 = 0b1000,
+  WS_STEP_44_1 = 0b0111,
+  WS_STEP_32 = 0b0110,
+  WS_STEP_24 = 0b0101,
+  WS_STEP_22_05 = 0b0100,
+  WS_STEP_16 = 0b0011,
+  WS_STEP_12 = 0b0010,
+  WS_STEP_11_025 = 0b0001,
+  WS_STEP_8 = 0,
+};
+
+struct RDA5807FP_I2SConfig
+{
+  bool enabled = false;
+  bool slave = false;
+  RDA5807FP_I2S_WS_CNT rate = WS_STEP_48;
+  bool data_signed = false;
+};
+
+// ----- library definition -----
+
+/// Library to control the RDA5807FP radio chip.
+class RDA5807FP : public RDA5807M
+{
+public:
+  RDA5807FP();
+
+  void SetupI2S(RDA5807FP_I2SConfig config);
+};
+
+#endif

--- a/src/RDA5807M.h
+++ b/src/RDA5807M.h
@@ -76,7 +76,7 @@ class RDA5807M : public RADIO {
   void    debugScan();               // Scan all frequencies and report a status
   void    debugStatus();             // DebugInfo about actual chip data available
 
-  private:
+  protected:
   // ----- local variables
   uint16_t registers[16];  // memory representation of the registers
 


### PR DESCRIPTION
RDA5807FP is based on RDA5807M but also offers audio output via I2S. I derived a new RDA5807FP class and added a method to configure I2S output with some basic settings (master/slave, signed data, word count). Tested with ESP32 and UDA1334A I2S DAC board.